### PR TITLE
ROS migration guide

### DIFF
--- a/img/ros_migration/Sender-Receiver.svg
+++ b/img/ros_migration/Sender-Receiver.svg
@@ -1,0 +1,129 @@
+<?xml version="1.0" standalone="no"?>
+
+<svg 
+     version="1.1"
+     baseProfile="full"
+     xmlns="http://www.w3.org/2000/svg"
+     xmlns:xlink="http://www.w3.org/1999/xlink"
+     xmlns:ev="http://www.w3.org/2001/xml-events"
+     xmlns:klighd="http://de.cau.cs.kieler/klighd"
+     x="0px"
+     y="0px"
+     width="178px"
+     height="63px"
+     viewBox="0 0 178 63"
+     >
+<title></title>
+<desc>Creator: FreeHEP Graphics2D Driver Producer: de.cau.cs.kieler.klighd.piccolo.freehep.SemanticSVGGraphics2D Revision Source:  Date: Thursday, June 9, 2022 at 2:51:38 PM Central Daylight Time</desc>
+<g stroke-dashoffset="0" stroke-linejoin="miter" stroke-dasharray="none" stroke-width="1" stroke-linecap="butt" stroke-miterlimit="10">
+<g fill="#ffffff" fill-rule="nonzero" fill-opacity="1" stroke="none">
+  <path d="M 0 0 L 178.39999389648438 0 L 178.39999389648438 63 L 0 63 L 0 0 z"/>
+</g>
+<g fill="#ffffff" fill-rule="nonzero" fill-opacity="1" stroke="none">
+  <path d="M 1 9 L 1 54 C 1 58.418277998646346 4.581722001353653 62 9 62 L 169.39999389648438 62 C 173.81827189513072 62 177.39999389648438 58.418277998646346 177.39999389648438 54 L 177.39999389648438 9 C 177.39999389648438 4.581722001353653 173.81827189513072 1 169.39999389648438 1 L 9 1 C 4.581722001353653 1 1 4.581722001353653 1 9 z"/>
+</g>
+<g stroke-opacity="1" stroke-width="2" fill="none" stroke="#bebebe">
+  <path d="M 1 9 L 1 54 C 1 58.418277998646346 4.581722001353653 62 9 62 L 169.39999389648438 62 C 173.81827189513072 62 177.39999389648438 58.418277998646346 177.39999389648438 54 L 177.39999389648438 9 C 177.39999389648438 4.581722001353653 173.81827189513072 1 169.39999389648438 1 L 9 1 C 4.581722001353653 1 1 4.581722001353653 1 9 z"/>
+</g>
+<g transform="matrix(1, 0, 0, 1, 28.199996948242188, 6)">
+  <text x="0" y="13.0" font-weight="normal" font-size="13.333333969116211px" font-family="Helvetica" style="white-space: pre" font-style="normal" fill="#000000" fill-opacity="1" stroke="none">Sender-Receiver</text>
+</g>
+<g transform="matrix(1, 0, 0, 1, 130.1999969482422, 14)">
+<g fill="#bebebe" fill-rule="nonzero" fill-opacity="1" stroke="none">
+  <path d="M 0.5 2.5 L 0.5 3.5 C 0.5 4.6045694996615865 1.3954305003384133 5.5 2.5 5.5 L 17.5 5.5 C 18.604569499661586 5.5 19.5 4.6045694996615865 19.5 3.5 L 19.5 2.5 C 19.5 1.3954305003384133 18.604569499661586 0.5 17.5 0.5 L 2.5 0.5 C 1.3954305003384133 0.5 0.5 1.3954305003384133 0.5 2.5 z"/>
+</g>
+</g>
+<g transform="matrix(1, 0, 0, 1, 130.1999969482422, 14)">
+<g stroke-opacity="1" fill="none" stroke="#bebebe">
+  <path d="M 0.5 2.5 L 0.5 3.5 C 0.5 4.6045694996615865 1.3954305003384133 5.5 2.5 5.5 L 17.5 5.5 C 18.604569499661586 5.5 19.5 4.6045694996615865 19.5 3.5 L 19.5 2.5 C 19.5 1.3954305003384133 18.604569499661586 0.5 17.5 0.5 L 2.5 0.5 C 1.3954305003384133 0.5 0.5 1.3954305003384133 0.5 2.5 z"/>
+</g>
+</g>
+<g transform="matrix(1, 0, 0, 1, 128.1999969482422, 12.079999923706055)">
+<g fill="#bebebe" fill-rule="nonzero" fill-opacity="1" stroke="none">
+  <path d="M 7.5 4 C 7.5 5.932996624407776 5.932996624407776 7.5 4 7.5 C 2.0670033755922232 7.5 0.5 5.932996624407776 0.5 4 C 0.5 2.0670033755922232 2.0670033755922232 0.5 4 0.5 C 5.932996624407776 0.5 7.5 2.0670033755922232 7.5 4 z"/>
+</g>
+</g>
+<g transform="matrix(1, 0, 0, 1, 128.1999969482422, 12.079999923706055)">
+<g stroke-opacity="1" fill="none" stroke="#bebebe">
+  <path d="M 7.5 4 C 7.5 5.932996624407776 5.932996624407776 7.5 4 7.5 C 2.0670033755922232 7.5 0.5 5.932996624407776 0.5 4 C 0.5 2.0670033755922232 2.0670033755922232 0.5 4 0.5 C 5.932996624407776 0.5 7.5 2.0670033755922232 7.5 4 z"/>
+</g>
+</g>
+<g transform="matrix(1, 0, 0, 1, 132.53333044052124, 10)">
+<g fill="#bebebe" fill-rule="nonzero" fill-opacity="1" stroke="none">
+  <path d="M 6.166666507720947 3.3333332538604736 C 6.166666507720947 4.898140001156072 4.898140001156072 6.166666507720947 3.3333332538604736 6.166666507720947 C 1.7685265065648743 6.166666507720947 0.5 4.898140001156072 0.5 3.3333332538604736 C 0.5 1.7685265065648743 1.7685265065648743 0.5 3.3333332538604736 0.5 C 4.898140001156072 0.5 6.166666507720947 1.7685265065648743 6.166666507720947 3.3333332538604736 z"/>
+</g>
+</g>
+<g transform="matrix(1, 0, 0, 1, 132.53333044052124, 10)">
+<g stroke-opacity="1" fill="none" stroke="#bebebe">
+  <path d="M 6.166666507720947 3.3333332538604736 C 6.166666507720947 4.898140001156072 4.898140001156072 6.166666507720947 3.3333332538604736 6.166666507720947 C 1.7685265065648743 6.166666507720947 0.5 4.898140001156072 0.5 3.3333332538604736 C 0.5 1.7685265065648743 1.7685265065648743 0.5 3.3333332538604736 0.5 C 4.898140001156072 0.5 6.166666507720947 1.7685265065648743 6.166666507720947 3.3333332538604736 z"/>
+</g>
+</g>
+<g transform="matrix(1, 0, 0, 1, 136.99999713897705, 8)">
+<g fill="#bebebe" fill-rule="nonzero" fill-opacity="1" stroke="none">
+  <path d="M 9.5 5 C 9.5 7.4852813742385695 7.4852813742385695 9.5 5 9.5 C 2.51471862576143 9.5 0.5 7.4852813742385695 0.5 5 C 0.5 2.51471862576143 2.51471862576143 0.5 5 0.5 C 7.4852813742385695 0.5 9.5 2.51471862576143 9.5 5 z"/>
+</g>
+</g>
+<g transform="matrix(1, 0, 0, 1, 136.99999713897705, 8)">
+<g stroke-opacity="1" fill="none" stroke="#bebebe">
+  <path d="M 9.5 5 C 9.5 7.4852813742385695 7.4852813742385695 9.5 5 9.5 C 2.51471862576143 9.5 0.5 7.4852813742385695 0.5 5 C 0.5 2.51471862576143 2.51471862576143 0.5 5 0.5 C 7.4852813742385695 0.5 9.5 2.51471862576143 9.5 5 z"/>
+</g>
+</g>
+<g transform="matrix(1, 0, 0, 1, 6, 25)">
+<g fill="#f2f2f2" fill-rule="nonzero" fill-opacity="1" stroke="none">
+  <path d="M 0.5 8.5 L 0.5 19.5 C 0.5 23.918277998646346 4.081722001353653 27.5 8.5 27.5 L 44.5 27.5 C 48.918277998646346 27.5 52.5 23.918277998646346 52.5 19.5 L 52.5 8.5 C 52.5 4.081722001353653 48.918277998646346 0.5 44.5 0.5 L 8.5 0.5 C 4.081722001353653 0.5 0.5 4.081722001353653 0.5 8.5 z"/>
+</g>
+</g>
+<g transform="matrix(1, 0, 0, 1, 6, 25)">
+<g stroke-opacity="1" fill="none" stroke="#bebebe">
+  <path d="M 0.5 8.5 L 0.5 19.5 C 0.5 23.918277998646346 4.081722001353653 27.5 8.5 27.5 L 44.5 27.5 C 48.918277998646346 27.5 52.5 23.918277998646346 52.5 19.5 L 52.5 8.5 C 52.5 4.081722001353653 48.918277998646346 0.5 44.5 0.5 L 8.5 0.5 C 4.081722001353653 0.5 0.5 4.081722001353653 0.5 8.5 z"/>
+</g>
+</g>
+<g transform="matrix(1, 0, 0, 1, 12, 32)">
+  <text x="0" y="13.0" font-weight="normal" font-size="13.333333969116211px" font-family="Helvetica" style="white-space: pre" font-style="normal" fill="#000000" fill-opacity="1" stroke="none">Sender</text>
+</g>
+<g transform="matrix(1, 0, 0, 1, 64.70000076293945, 44)">
+  <text x="0" y="10.0" font-weight="normal" font-size="10.666666984558105px" font-family="Helvetica" style="white-space: pre" font-style="normal" fill="#000000" fill-opacity="1" stroke="none">out</text>
+</g>
+<g transform="matrix(1, 0, 0, 1, 55.70000076293945, 35)">
+<g fill="#000000" fill-rule="nonzero" fill-opacity="1" stroke="none">
+  <path d="M 0 0 L 8 4 L 0 8 z"/>
+</g>
+</g>
+<g transform="matrix(1, 0, 0, 1, 55.70000076293945, 35)">
+<g stroke-opacity="1" fill="none" stroke="#000000">
+  <path d="M 0 0 L 8 4 L 0 8 z"/>
+</g>
+</g>
+<g transform="matrix(1, 0, 0, 1, 108.39999389648438, 25)">
+<g fill="#f2f2f2" fill-rule="nonzero" fill-opacity="1" stroke="none">
+  <path d="M 0.5 8.5 L 0.5 19.5 C 0.5 23.918277998646346 4.081722001353653 27.5 8.5 27.5 L 55.5 27.5 C 59.918277998646346 27.5 63.5 23.918277998646346 63.5 19.5 L 63.5 8.5 C 63.5 4.081722001353653 59.918277998646346 0.5 55.5 0.5 L 8.5 0.5 C 4.081722001353653 0.5 0.5 4.081722001353653 0.5 8.5 z"/>
+</g>
+</g>
+<g transform="matrix(1, 0, 0, 1, 108.39999389648438, 25)">
+<g stroke-opacity="1" fill="none" stroke="#bebebe">
+  <path d="M 0.5 8.5 L 0.5 19.5 C 0.5 23.918277998646346 4.081722001353653 27.5 8.5 27.5 L 55.5 27.5 C 59.918277998646346 27.5 63.5 23.918277998646346 63.5 19.5 L 63.5 8.5 C 63.5 4.081722001353653 59.918277998646346 0.5 55.5 0.5 L 8.5 0.5 C 4.081722001353653 0.5 0.5 4.081722001353653 0.5 8.5 z"/>
+</g>
+</g>
+<g transform="matrix(1, 0, 0, 1, 114.39999389648438, 32)">
+  <text x="0" y="13.0" font-weight="normal" font-size="13.333333969116211px" font-family="Helvetica" style="white-space: pre" font-style="normal" fill="#000000" fill-opacity="1" stroke="none">Receiver</text>
+</g>
+<g transform="matrix(1, 0, 0, 1, 94.69999408721924, 44)">
+  <text x="0" y="10.0" font-weight="normal" font-size="10.666666984558105px" font-family="Helvetica" style="white-space: pre" font-style="normal" fill="#000000" fill-opacity="1" stroke="none">in</text>
+</g>
+<g transform="matrix(1, 0, 0, 1, 103.69999408721924, 35)">
+<g fill="#000000" fill-rule="nonzero" fill-opacity="1" stroke="none">
+  <path d="M 0 0 L 8 4 L 0 8 z"/>
+</g>
+</g>
+<g transform="matrix(1, 0, 0, 1, 103.69999408721924, 35)">
+<g stroke-opacity="1" fill="none" stroke="#000000">
+  <path d="M 0 0 L 8 4 L 0 8 z"/>
+</g>
+</g>
+<g transform="matrix(1, 0, 0, 1, 0, 26)">
+<g stroke-opacity="1" fill="none" stroke="#000000">
+  <path d="M 63.70000076293945 13 L 103.69999694824219 13"/>
+</g>
+</g>
+</g>
+</svg>

--- a/packages/documentation/copy/en/developer/ROS Migration Guide.md
+++ b/packages/documentation/copy/en/developer/ROS Migration Guide.md
@@ -1,0 +1,315 @@
+---
+title: "ROS Migration Guide"
+layout: docs
+permalink: /docs/handbook/ros-migration-guide
+oneline: "ROS Migration Guide."
+preamble: >
+---
+
+<div class="lf-c">
+
+## ROS 2 Interoperability
+
+The C target has several features that would allow you to mostly re-use your existing rclcpp-based ROS 2 nodes with minimal required changes:
+
+- **`CCpp` target:** Since you might want to write C++ code and interact with
+  C++ libraries, we have added a special [CCpp
+  target](/docs/handbook/target-language-details#the-target-specification)
+  that uses the C runtime under the hood and the existing CMake build system in
+  the C target. However, the CCpp target uses a C++ compiler instead of a C
+  compiler. To use the CCpp target, simply declare your target as
+  ```lf-c
+  target CCpp <options>;
+  ```
+- **Interoperability with Colcon:** The C target uses the same underlying build
+  system as `colcon` (and `ament`), and thus can nicely interoperate with
+  CMake-based ROS packages (which include most C/C++ packages). To add an existing ROS
+  package or node as a build dependency, you could make use of the
+  [`cmake-include`](/docs/handbook/target-declaration#cmake) target parameter.
+  For example, to use `rclcpp`, you could do the following:
+
+  ```lf-c
+  target CCpp {
+      cmake-include: ["rclcpp-support.cmake",]
+  };
+  ```
+
+  And write the `rclcpp-support.cmake` as follows:
+
+  ```lf-c
+  find_package(ament_cmake REQUIRED)
+  find_package(rclcpp REQUIRED)
+  ament_target_dependencies(${LF_MAIN_TARGET} rclcpp)
+  ```
+
+  Note the use of `ament_target_dependencies`, which is not a built-in CMake
+  method. `ament_target_dependencies` is a CMake method that is provided as part
+  of the
+  [`ament_cmake`](https://docs.ros.org/en/humble/How-To-Guides/Ament-CMake-Documentation.html#ament-cmake-user-documentation)
+  package and is more or less a shortcut for including and linking target
+  dependencies (including any relevant directories that may contain header
+  files).
+
+  Also note that ROS setup files should be properly [sourced](https://docs.ros.org/en/humble/Tutorials/Configuring-ROS2-Environment.html#source-the-setup-files) in order for `rclcpp` to be findable.
+
+- **Built-in Support for ROS 2 Message Types:** The CCpp target has built-in
+  support for ROS 2 message (and service) types. Messages are still transported
+  on (deterministic) Lingua Franca connections, but reactor ports can have ROS
+  2 message (or service) types. In federated execution, rclcpp's serializer is
+  transparently used to serialize messages.
+
+  For example, you could write a
+  simple Lingua Franca program where a `Sender` reactor sends a
+  `std_msgs::msg::Int32` to a `Receiver` reactor as follows:
+
+  ```lf-c
+  target CCpp {
+      cmake-include: ["ros-support.cmake",]
+  };
+  preamble {=
+      #include "std_msgs/msg/int32.hpp"
+  =}
+  reactor Sender {
+      output out:std_msgs::msg::Int32;
+      reaction (startup) -> out {=
+          std_msgs::msg::Int32 ros_message;
+          ros_message.data = 1;
+          lf_set(out, ros_message);
+      =}
+  }
+  reactor Receiver {
+    input in:std_msgs::msg::Int32;
+    reaction (in) {=
+        // Print the ROS2 message data
+        lf_print("Received: %d", in->value.data);
+    =}
+  }
+  federated reactor { // Also works with main
+      sender = new Sender();
+      receiver = new Receiver();
+      sender.out -> receiver.in serializer "ros2";
+  }
+  ```
+
+  <img alt="Lingua Franca diagram" src="../../../../../img/ros_migration/Sender-Receiver.svg" width="350"/>
+
+  The `ros-support.cmake` simply contains:
+
+  ```lf-c
+  find_package(std_msgs REQUIRED)
+  ament_target_dependencies(${LF_MAIN_TARGET} std_msgs)
+  ```
+
+  Note the use of `serializer "ros2"` on the connection between the sender and
+  receiver. This tells the Lingua Franca compiler what serializer it should use
+  on the connection.
+
+  Also note the minimal content of `ros-support.cmake` (notably with `rclcpp`
+  being absent). Because of the usage of `serializer "ros2"`, the Lingua Franca
+  compiler will automatically add basic ROS 2 packages (`ament_cmake`, `rclcpp`,
+  `rclcpp_components`, `rcutils`, and `rmw`) as build dependencies.
+
+  Finally, as a reminder, please note that ROS setup files should be properly
+  [sourced](https://docs.ros.org/en/humble/Tutorials/Configuring-ROS2-Environment.html#source-the-setup-files)
+  in order for `std_msgs` to be findable.
+
+  Support for `shared_ptr` types is also supported. It is generally could be
+  more efficient to use shared pointers because they can minimize the overhead
+  of copying. This would especially be useful for message types such as
+  `PointCloud2` that are expensive to copy. The example above could be
+  re-written as:
+
+  ```lf-c
+  target CCpp {
+      cmake-include: ["ros-support.cmake",]
+  };
+  preamble {=
+      #include <memory>
+      #include "std_msgs/msg/int32.hpp"
+  =}
+  reactor Sender {
+      output out:std::shared_ptr<std_msgs::msg::Int32>;
+      reaction (startup) -> out {=
+          auto ros_message = std::make_shared<std_msgs::msg::Int32>();
+          ros_message->data = 1;
+          lf_set(out, ros_message);
+      =}
+  }
+  reactor Receiver {
+      input in:std::shared_ptr<std_msgs::msg::Int32>;
+      reaction (in) {=
+          // Print the ROS2 message data
+          lf_print("Received: %d", in->value->data);
+      =}
+  }
+  federated reactor {
+      sender = new Sender();
+      receiver = new Receiver();
+      sender.out -> receiver.in serializer "ros2";
+  }
+  ```
+
+## Porting ROS 2 Nodes to Lingua Franca
+
+In addition to using ROS 2 packages in your Lingua Franca programs, you could
+also take steps to port existing ROS 2 nodes to Lingua Franca. Ultimately,
+Lingua Franca can take over the communication and the event handling control
+loop of existing ROS 2 nodes to enable deterministic execution.
+
+Here, we show the required steps to port the publisher and subscriber nodes in
+ROS 2's [`minimal composition`](https://github.com/ros2/examples/tree/master/rclcpp/composition/minimal_composition)
+example to Lingua Franca. The instructions are written with the assumption that
+you would be using Ubuntu 22.04 and ROS 2 Humble. However, the overall steps
+should work on all non-deprecated and fully supported ROS 2
+[distributions](https://docs.ros.org/en/humble/Releases.html).
+
+### Putting ROS 2 nodes inside reactors
+
+- Step 1: [Install ROS 2](https://docs.ros.org/en/humble/Installation.html).
+- Step 2: [Install LFC](/docs/handbook/command-line-tools).
+- Step 3: Create a folder that would contain everything. For example:
+
+  ```bash
+  mkdir ~/lf-ros-demo/
+  cd ~/lf-ros-demo
+  ```
+
+- Step 4: Clone the ROS 2 examples repository:
+
+  ```bash
+  git clone --branch humble git@github.com:ros2/examples.git
+  # Navigate to where minimal_composition located
+  cd examples/rclcpp/composition/minimal_composition
+  ```
+
+  Note the inclusion of `--branch humble` above. You would want to clone the
+  branch that corresponds to your ROS distribution.
+
+- Step 5: [Source the appropriate setup file for your system](https://docs.ros.org/en/humble/Tutorials/Configuring-ROS2-Environment.html#source-the-setup-files). For example:
+
+  ```bash
+  source /opt/ros/humble/setup.bash
+  ```
+
+- Step 6: Build and source the project (see the note below).
+
+  ```bash
+  colcon build --allow-overriding examples_rclcpp_minimal_composition
+  source install/setup.bash
+  ```
+
+  **Important note:** In most cases `minimal_composition` is already built on your
+  system because it comes with the default installation of ROS 2. The
+  `--allow-overriding examples_rclcpp_minimal_composition` option allows us to
+  override that default installation locally for the purposes of demonstration.
+  You won't need this option for your homegrown ROS 2 nodes.
+
+- Step 7: Now, we are going to create a `Sender` reactor that incorporates the
+  [`publisher_node`](https://github.com/ros2/examples/blob/master/rclcpp/composition/minimal_composition/src/publisher_node.cpp)
+  and a `Receiver` reactor that incorporates the
+  [`subscriber_node`](https://github.com/ros2/examples/blob/master/rclcpp/composition/minimal_composition/src/subscriber_node.cpp)
+  node.
+
+  - Step 7.1: Create a Lingua Franca [project](/docs/handbook/a-first-reactor#structure-of-an-lf-project):
+
+  ```bash
+  mkdir -p ~/lf-ros-demo/lf-project/src
+  cd ~/lf-ros-demo/lf-project/src
+  ```
+
+  - Step 7.2: Use any of our [editors](/download) to create a
+    `Sender.lf` and a `Receiver.lf` file with the following content:
+
+    ```lf-c
+    // ~/lf-ros-demo/lf-project/src/Sender.lf
+    target CCpp {
+      cmake-include: "include/composition.cmake"
+    };
+    preamble {=
+      #include <memory>
+      #include "minimal_composition/publisher_node.hpp"
+      #include "rclcpp/rclcpp.hpp"
+      #include "std_msgs/msg/string.hpp"
+    =}
+    reactor Sender {
+      // Instantiate the publisher node as a sate variable
+      state publisher_node : std::shared_ptr<PublisherNode>;
+      reaction(startup) {=
+        // Initialize rclcpp
+        rclcpp::init(0, NULL);
+        // Instantiate the ROS node
+        // Note: Sending messages is still done in ROS
+        self->publisher_node = std::make_shared<PublisherNode>(rclcpp::NodeOptions());
+        // Start the rclcpp's event handling loop
+        // Event handling is still done in ROS
+        rclcpp::spin(self->publisher_node);
+      =}
+      reaction(shutdown) {=
+        rclcpp::shutdown();
+      =}
+    }
+
+    ```
+
+    ```lf-c
+    // ~/lf-ros-demo/lf-project/src/Receiver.lf
+    target CCpp {
+      cmake-include: "include/composition.cmake"
+    };
+    preamble {=
+      #include <memory>
+      #include "minimal_composition/subscriber_node.hpp"
+      #include "rclcpp/rclcpp.hpp"
+      #include "std_msgs/msg/string.hpp"
+    =}
+    reactor Receiver {
+      // Instantiate the subscriber node as a sate variable
+      state subscriber_node : std::shared_ptr<SubscriberNode>;
+      reaction(startup) {=
+        // Initialize rclcpp
+        rclcpp::init(0, NULL);
+        // Instantiate the ROs node
+        // Note: Receiving messages is still done in ROS
+        self->subscriber_node = std::make_shared<SubscriberNode>(rclcpp::NodeOptions());
+        // Start the rclcpp's event handling loop
+        // Event handling is still done in ROS
+        rclcpp::spin(self->subscriber_node);
+      =}
+      reaction(shutdown) {=
+        rclcpp::shutdown();
+      =}
+    }
+    ```
+
+    Since reactors are composable, you could create a [federated]() program that
+    incorporates both the Sender and the Receiver:
+
+    ```lf-c
+    // ~/lf-ros-demo/lf-project/src/Main.lf
+    target CCpp;
+
+    import Sender from "Sender.lf"
+    import Receiver from "Receiver.lf"
+
+    federated reactor {
+        sender = new Sender();
+        receiver = new Receiver();
+    }
+
+    ```
+
+    **FIXME:** Following the steps above will cause the following error: "undefined reference to `SubscriberNode::SubscriberNode(rclcpp::NodeOptions)'".
+
+</div>
+
+<div class="lf-cpp">
+FIXME: @cmnrd
+</div>
+
+<div class="lf-py">
+ROS integration with the Python target is still under development.
+</div>
+
+<div class="lf-ts lf-rs">
+ROS integration for the selected target is not yet supported.
+</div>

--- a/packages/documentation/copy/en/developer/ROS Migration Guide.md
+++ b/packages/documentation/copy/en/developer/ROS Migration Guide.md
@@ -113,7 +113,7 @@ The C target has several features that would allow you to mostly re-use your exi
   [sourced](https://docs.ros.org/en/humble/Tutorials/Configuring-ROS2-Environment.html#source-the-setup-files)
   in order for `std_msgs` to be findable.
 
-  Support for `shared_ptr` types is also supported. It is generally could be
+  Support for `shared_ptr` types is also supported. It could be
   more efficient to use shared pointers because they can minimize the overhead
   of copying. This would especially be useful for message types such as
   `PointCloud2` that are expensive to copy. The example above could be

--- a/packages/documentation/copy/en/developer/ROS Migration Guide.md
+++ b/packages/documentation/copy/en/developer/ROS Migration Guide.md
@@ -396,6 +396,20 @@ reactor Receiver {
 }
 ```
 
+```lf-c
+// ~/lf-ros-demo/lf-project/src/Main.lf
+target CCpp;
+
+import Sender from "Sender.lf"
+import Receiver from "Receiver.lf"
+
+federated reactor {
+    sender = new Sender();
+    receiver = new Receiver();
+    sender.out -> receiver.in serializer "ROS2";
+}
+```
+
 **FIXME**: Add figures for the examples above.
 
 </div>

--- a/packages/documentation/copy/en/developer/ROS Migration Guide.md
+++ b/packages/documentation/copy/en/developer/ROS Migration Guide.md
@@ -163,7 +163,7 @@ you would be using Ubuntu 22.04 and ROS 2 Humble. However, the overall steps
 should work on all non-deprecated and fully supported ROS 2
 [distributions](https://docs.ros.org/en/humble/Releases.html).
 
-### Putting ROS 2 nodes inside reactors
+### Step 1: Put the ROS 2 node inside a reactor
 
 - Step 1: [Install ROS 2](https://docs.ros.org/en/humble/Installation.html).
 - Step 2: [Install LFC](/docs/handbook/command-line-tools).
@@ -299,6 +299,10 @@ should work on all non-deprecated and fully supported ROS 2
     ```
 
     **FIXME:** Following the steps above will cause the following error: "undefined reference to `SubscriberNode::SubscriberNode(rclcpp::NodeOptions)'".
+
+### Step 2: Take over the communication of the node
+
+**FIXME:**
 
 </div>
 

--- a/packages/documentation/scripts/generateDocsNavigationPerLanguage.js
+++ b/packages/documentation/scripts/generateDocsNavigationPerLanguage.js
@@ -93,6 +93,7 @@ const handbookPages = [
       { file: "developer/Downloading and Building.md" },
       { file: "developer/Developer Eclipse Setup with Oomph.md" },
       { file: "developer/Developer IntelliJ Setup (for Kotlin).md" },
+      { file: "developer/ROS Migration Guide.md" },
       { file: "developer/Running Benchmarks.md" },
     ]
   },

--- a/packages/lingua-franca/src/lib/documentationNavigation.ts
+++ b/packages/lingua-franca/src/lib/documentationNavigation.ts
@@ -263,6 +263,12 @@ export function getDocumentationNavForLanguage(
           oneline: "Developer IntelliJ Setup (for Kotlin).",
         },
         {
+          title: "ROS Migration Guide",
+          id: "4-ros-migration-guide",
+          permalink: "/docs/handbook/ros-migration-guide",
+          oneline: "ROS Migration Guide.",
+        },
+        {
           title: "Running Benchmarks",
           id: "4-running-benchmarks",
           permalink: "/docs/handbook/running-benchmarks",

--- a/packages/lingua-franca/src/templates/pages/download.tsx
+++ b/packages/lingua-franca/src/templates/pages/download.tsx
@@ -17,7 +17,7 @@ const Index: React.FC<Props> = (props) => {
       <h1>Download and Install Lingua Franca</h1>
       <p>
         All Lingua Franca tools require Java 17 or up (<a href="https://www.oracle.com/java/technologies/downloads/">download from Oracle</a>).
-        Each target language may have additional requirements. See the <a href="/docs/handbook/target-language-details#requirements">Target Language Details</a>) page and select your target language.
+        Each target language may have additional requirements. See the <a href="/docs/handbook/target-language-details#requirements">Target Language Details</a> page and select your target language.
         The alternatives:
         <ul>
           <li><a href="#vscode">Use the Visual Studio Code extension</a></li>


### PR DESCRIPTION
This is the first draft of the ROS migration guide.

However, it is incomplete.

To-Do:
- [ ] Fix the ld error mentioned below 
- [ ] Write the section titled "Step 2: Take over the communication of the node"


Following Step 1 of the guide will yield the following error:
```bash
/usr/bin/ld: CMakeFiles/Main_receiver.dir/Main_receiver.cpp.o: in function `receiverreaction_function_0(void*)':
Main_receiver.cpp:(.text+0xcc5c): undefined reference to `SubscriberNode::SubscriberNode(rclcpp::NodeOptions)'
collect2: error: ld returned 1 exit status
gmake[2]: *** [CMakeFiles/Main_receiver.dir/build.make:287: Main_receiver] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:85: CMakeFiles/Main_receiver.dir/all] Error 2
gmake: *** [Makefile:146: all] Error 2
[100%] Linking CXX executable Main_sender
/usr/bin/ld: CMakeFiles/Main_sender.dir/Main_sender.cpp.o: in function `senderreaction_function_0(void*)':
Main_sender.cpp:(.text+0xcbf4): undefined reference to `PublisherNode::PublisherNode(rclcpp::NodeOptions)'
collect2: error: ld returned 1 exit status
gmake[2]: *** [CMakeFiles/Main_sender.dir/build.make:287: Main_sender] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:85: CMakeFiles/Main_sender.dir/all] Error 2
gmake: *** [Makefile:146: all] Error 2
Compiled binary is in /home/soroush/lf-ros-demo/lf-project/bin
lfc: error:  failed with error code 2
 --> (unknown file):null:1 -  failed with error code 2

lfc: fatal error: Aborting due to previous error
```