### PR TITLE
Fix handbook linking 0.2.0 version to 0.3.0

### DIFF
--- a/packages/documentation/copy/en/reference/Target Declaration.md
+++ b/packages/documentation/copy/en/reference/Target Declaration.md
@@ -337,7 +337,7 @@ target Cpp {
 };
 ```
 
-This will optionally append additional custom CMake instructions to the generated `CMakeLists.txt`, drawing these instructions from the specified text files (e.g, `foo.txt`). The specified files are resolved using the same file search algorithm as used for the [files](#files) target parameter. Those files will be copied into the `src-gen` directory that contains the generated sources. This is done to make the generated code more portable<span class="lf-c"> (a feature that is useful in [federated execution](/docs/handbook/distributed-execution)</span>.
+This will optionally append additional custom CMake instructions to the generated `CMakeLists.txt`, drawing these instructions from the specified text files (e.g, `foo.txt`). The specified files are resolved using the same file search algorithm as used for the [files](#files) target parameter. Those files will be copied into the `src-gen` directory that contains the generated sources. This is done to make the generated code more portable<span class="lf-c"> (a feature that is useful in [federated execution](/docs/handbook/distributed-execution))</span>.
 
 The cmake-include target property can be used, for example, to add dependencies on various packages (e.g., by using the [`find_package`](https://cmake.org/cmake/help/latest/command/find_package.html) and [`target_link_libraries`](https://cmake.org/cmake/help/latest/command/target_link_libraries.html) commands).
 

--- a/packages/documentation/copy/en/tools/Command Line Tools.md
+++ b/packages/documentation/copy/en/tools/Command Line Tools.md
@@ -13,20 +13,20 @@ To download the current development version of the command-line tools instead of
 
 ### Linux and macOS
 
-Download <a href="https://github.com/lf-lang/lingua-franca/releases/download/v0.2.0/lfc_0.2.0.tar.gz">lfc 0.2.0 for Linux/Mac</a> and run:
+Download <a href="https://github.com/lf-lang/lingua-franca/releases/download/v0.3.0/lfc_0.3.0.tar.gz">lfc 0.3.0 for Linux/Mac</a> and run:
 
 ```shell
-    tar xvf lfc_0.2.0.tar.gz
-    ./lfc_0.2.0/bin/lfc --help
+    tar xvf lfc_0.3.0.tar.gz
+    ./lfc_0.3.0/bin/lfc --help
 ```
 
 ### Windows
 
-Download <a href="https://github.com/lf-lang/lingua-franca/releases/download/v0.2.0/lfc_0.2.0.zip">lfc 0.2.0 for Windows</a> and run:
+Download <a href="https://github.com/lf-lang/lingua-franca/releases/download/v0.3.0/lfc_0.3.0.zip">lfc 0.3.0 for Windows</a> and run:
 
 ```powershell
-    unzip lfc_0.2.0.zip
-    .\lfc_0.2.0\bin\lfc.ps1 --version
+    unzip lfc_0.3.0.zip
+    .\lfc_0.3.0\bin\lfc.ps1 --version
 ```
 
 ### Developer

--- a/packages/documentation/copy/en/topics/Distributed Execution.md
+++ b/packages/documentation/copy/en/topics/Distributed Execution.md
@@ -20,7 +20,7 @@ $page-showing-target$
 
 A distributed Lingua Franca program is called a **federation**. Each reactor within the main reactor is called a **federate**. The LF compiler generates a separate program for each federate and synthesizes the code for the federates to communicate. The federates can be distributed across networks and eventually will be able to be written in different target languages, although this is not yet supported.
 
-In addition to the federates, there is a program called the **RTI**, for **runtime infrastructure**. that coordinates startup and shutdown and may, if the coordination is centralized, mediate communication. The RTI needs to be compiled and installed separately on the system before any federation can execute.
+In addition to the federates, there is a program called the **RTI**, for **runtime infrastructure**, that coordinates startup and shutdown and may, if the coordination is centralized, mediate communication. The RTI needs to be compiled and installed separately on the system before any federation can execute.
 
 It is possible to encapsulate federates in Docker containers for deployment.
 See [containerized execution](/docs/handbook/containerized-execution).

--- a/packages/documentation/copy/en/topics/Multiports and Banks.md
+++ b/packages/documentation/copy/en/topics/Multiports and Banks.md
@@ -209,7 +209,7 @@ In the Python target, multiports can be iterated on in a for loop (e.g., `for p 
 ## Sparse Inputs
 
 Sometimes, a program needs a wide multiport input, but when reactions are triggered by this input, few of the channels are present.
-In this case, it can inefficient to iterate over all the channels to determine which are present.
+In this case, it can be inefficient to iterate over all the channels to determine which are present.
 If you know that a multiport input will be **sparse** in this way, then you can provide a hint to the compiler and use a more efficient iterator to access the port. For example:
 
 $start(Sparse)$


### PR DESCRIPTION
Fix https://www.lf-lang.org/docs/handbook/command-line-tools?target=c page linking 0.2.0 to 0.3.0.