### PR TITLE
Document preamble for the C target

### DIFF
--- a/packages/documentation/code/c/.gitignore
+++ b/packages/documentation/code/c/.gitignore
@@ -1,0 +1,1 @@
+include/

--- a/packages/documentation/code/c/src/lib/Cos.lf
+++ b/packages/documentation/code/c/src/lib/Cos.lf
@@ -1,0 +1,13 @@
+/**
+ * This example is included in Preambles.md, but not automatically imported.
+ * Success of the test is compiling and running.
+ */
+target C
+preamble {=
+    #include <math.h>
+=}
+reactor Cos {
+    reaction(startup) {=
+        printf("The cosine of 1 is %f.\n", cos(1));
+    =}
+}

--- a/packages/documentation/code/c/src/test/PreambleTest1.lf
+++ b/packages/documentation/code/c/src/test/PreambleTest1.lf
@@ -1,0 +1,13 @@
+/**
+ * This example is included in Preambles.md, but not automatically imported.
+ * Success of the test is compiling and running.
+ */
+target C
+main reactor {
+    preamble {=
+        #include <math.h>
+    =}
+    reaction(startup) {=
+        printf("The cosine of 1 is %f.\n", cos(1));
+    =}
+}

--- a/packages/documentation/code/c/src/test/PreambleTest2.lf
+++ b/packages/documentation/code/c/src/test/PreambleTest2.lf
@@ -1,0 +1,22 @@
+/**
+ * This example is included in Preambles.md, but not automatically imported.
+ * Success of the test is compiling and running.
+ */
+target C
+preamble {=
+    #include <math.h>
+=}
+reactor Cos {
+    reaction(startup) {=
+        printf("The cosine of 1 is %f.\n", cos(1));
+    =}
+}
+reactor Sin {
+    reaction(startup) {=
+        printf("The sine of 1 is %f.\n", sin(1));
+    =}
+}
+main reactor {
+    c = new Cos()
+    s = new Sin()
+}

--- a/packages/documentation/code/c/src/test/PreambleTest3.lf
+++ b/packages/documentation/code/c/src/test/PreambleTest3.lf
@@ -1,0 +1,18 @@
+/**
+ * This example is included in Preambles.md, but not automatically imported.
+ * Success of the test is compiling and running.
+ */
+target C
+import Cos from "../lib/Cos.lf"
+preamble {=
+    #include <math.h>
+=}
+reactor Sin {
+    reaction(startup) {=
+        printf("The sine of 1 is %f.\n", sin(1));
+    =}
+}
+main reactor {
+    c = new Cos()
+    s = new Sin()
+}

--- a/packages/documentation/code/c/src/test/PreambleTest4.lf
+++ b/packages/documentation/code/c/src/test/PreambleTest4.lf
@@ -1,0 +1,18 @@
+/**
+ * This example is included in Preambles.md, but not automatically imported.
+ * Success of the test is compiling and running.
+ */
+target C
+main reactor {
+    preamble {=
+        int add_42(int i) {
+            return i + 42;
+        }
+    =}
+    reaction(startup) {=
+        printf("42 plus 42 is %d.\n", add_42(42));
+    =}
+    reaction(startup) {=
+        printf("42 plus 1 is %d.\n", add_42(1));
+    =}
+}

--- a/packages/documentation/code/c/src/test/PreambleTest5.lf
+++ b/packages/documentation/code/c/src/test/PreambleTest5.lf
@@ -1,0 +1,27 @@
+/**
+ * This example is included in Preambles.md, but not automatically imported.
+ * Success of the test is compiling and running.
+ */
+target C
+preamble {=
+    int add_42(int i);
+=}
+reactor Add_42 {
+    reaction(startup) {=
+        printf("42 plus 42 is %d.\n", add_42(42));
+    =}
+}
+reactor Add_1 {
+    reaction(startup) {=
+        printf("42 plus 1 is %d.\n", add_42(1));
+    =}
+}
+main reactor {
+    preamble {=
+        int add_42(int i) {
+            return i + 42;
+        }
+    =}
+    a = new Add_42()
+    b = new Add_1()
+}

--- a/packages/documentation/code/c/src/test/PreambleTest6.lf
+++ b/packages/documentation/code/c/src/test/PreambleTest6.lf
@@ -1,0 +1,25 @@
+/**
+ * This example is included in Preambles.md, but not automatically imported.
+ * Success of the test is compiling and running.
+ */
+target C
+preamble {=
+    extern const char shared_string[];
+=}
+reactor A {
+    reaction(startup) {=
+        printf("Reactor A says %s.\n", shared_string);
+    =}
+}
+reactor B {
+    reaction(startup) {=
+        printf("Reactor B says %s.\n", shared_string);
+    =}
+}
+main reactor {
+    preamble {=
+        const char shared_string[] = "Hello";
+    =}
+    a = new A()
+    b = new B()
+}

--- a/packages/documentation/copy/en/topics/Preambles.md
+++ b/packages/documentation/copy/en/topics/Preambles.md
@@ -14,18 +14,15 @@ Reactions may contain arbitrary target-language code, but often it is convenient
 
 <div class="lf-c">
 
-For example, the following reactor uses the common `stdlib` C library to convert a string to an integer:
+For example, the following reactor uses the `math` C library for its trigonometric functions:
 
 ```lf-c
 main reactor {
     preamble {=
-        #include <stdlib.h>
+        #include <math.h>
     =}
-    timer t;
-    reaction(t) {=
-        char* s = "42";
-        int i = atoi(s);
-        printf("Converted string %s to int %d.\n", s, i);
+    reaction(startup) {=
+        printf("The cosine of 1 is %f.\n", cos(1));
     =}
 }
 ```
@@ -33,12 +30,33 @@ main reactor {
 This will print:
 
 ```
-Converted string 42 to int 42.
+The cosine of 1 is 0.540302.
 ```
 
-By putting the `#include` in the $preamble$, the library becomes available in all reactions of this reactor. Oddly, it also becomes available in all subsequently defined reactors in the same file or in files that include this file.
+By putting the `#include` in the $preamble$, the library becomes available in all reactions of this reactor.
+If you wish to have the library available in all reactors in the same file, you can provide the $preamble$ outside the reactor, as shown here:
 
-You can also use the $preamble$ to define functions that are shared across reactions and reactors, as in this example:
+```lf-c
+preamble {=
+    #include <math.h>
+=}
+reactor Cos {
+    reaction(startup) {=
+        printf("The cosine of 1 is %f.\n", cos(1));
+    =}
+}
+reactor Sin {
+    reaction(startup) {=
+        printf("The sine of 1 is %f.\n", sin(1));
+    =}
+}
+main reactor {
+    c = new Cos()
+    s = new Sin()
+}
+```
+
+You can also use the $preamble$ to define functions that are shared across reactions within a reactor, as in this example:
 
 ```lf-c
 main reactor {
@@ -47,9 +65,11 @@ main reactor {
             return i + 42;
         }
     =}
-    timer t;
-    reaction(t) {=
+    reaction(startup) {=
         printf("42 plus 42 is %d.\n", add_42(42));
+    =}
+    reaction(startup) {=
+        printf("42 plus 1 is %d.\n", add_42(1));
     =}
 }
 ```
@@ -58,10 +78,99 @@ Not surprisingly, this will print:
 
 ```
 42 plus 42 is 84.
+42 plus 1 is 43.
 ```
 
-A $preamble$ can also be put outside the $reactor$ definition.
-Currently, in the C target, it makes no difference whether it is put inside or outside.
+(The order in which these are printed is arbitrary because the reactions can execute in parallel.)
+
+To share a function across _reactors_, however, is a bit trickers.
+A $preamble$ that is put outside the $reactor$ definition can only contain
+_declarations_ not _definitions_ of functions or variables.
+The following code, for example will **fail to compile**:
+
+```
+preamble {=
+    int add_42(int i) {
+        return i + 42;
+    }
+=}
+reactor Add_42 {
+    reaction(startup) {=
+        printf("42 plus 42 is %d.\n", add_42(42));
+    =}
+}
+reactor Add_1 {
+    reaction(startup) {=
+        printf("42 plus 1 is %d.\n", add_42(1));
+    =}
+}
+main reactor {
+    a = new Add_42()
+    b = new Add_1()
+}
+```
+
+The compiler will issue a **duplicate symbol** error because the function definition gets repeated in the separate C files generated for the two reactor classes, `Add_42` and `Add_1`. When the compiled C code gets linked, the linker will find two definitions for the function `add_42`.
+
+To correct this compile error, the file-level preamble should contain only a _declaration_, not a _definition_, as here:
+
+```
+preamble {=
+    int add_42(int i);
+=}
+reactor Add_42 {
+    reaction(startup) {=
+        printf("42 plus 42 is %d.\n", add_42(42));
+    =}
+}
+reactor Add_1 {
+    reaction(startup) {=
+        printf("42 plus 1 is %d.\n", add_42(1));
+    =}
+}
+main reactor {
+    preamble {=
+        int add_42(int i) {
+            return i + 42;
+        }
+    =}
+    a = new Add_42()
+    b = new Add_1()
+}
+```
+
+The function _definition_ here is put into the main reactor, but it can be put in any reactor defined in the file.
+
+Most header files contain only declarations, and hence can be safely included
+using `#include` in a file-level $preamble$. If you wish to use a header file that includes both declarations and definitions, then you will need to include it within each reactor that uses it.
+
+If you wish to share _variables_ across reactors, similar constraints apply.
+Note that sharing variables across reactors is **strongly discouraged** because it can undermine the determinacy of Lingua Franca, and you may have to implement mutual-exclusion locks to access such variables. But it is occassionaly justfiable, as in the following example:
+
+```
+preamble {=
+    extern const char shared_string[];
+=}
+reactor A {
+    reaction(startup) {=
+        printf("Reactor A says %s.\n", shared_string);
+    =}
+}
+reactor B {
+    reaction(startup) {=
+        printf("Reactor B says %s.\n", shared_string);
+    =}
+}
+main reactor {
+    preamble {=
+        const char shared_string[] = "Hello";
+    =}
+    a = new A()
+    b = new B()
+}
+```
+
+Notice the use of the `extern` keyword in C, which is required because the _definition_ of the `shared_string` variable will be in a separate (code-generated) C file, the one for `main`, not the ones for `A` and `B`.
 
 </div>
 

--- a/packages/documentation/scripts/linguaFrancaUtils.js
+++ b/packages/documentation/scripts/linguaFrancaUtils.js
@@ -19,7 +19,7 @@ const keywords = [
   "main", "method", "mode", "msec", "msecs", "mutable", "mutation", 
   "new", 
   "output", 
-  "physical", "preamble",
+  "physical", "preamble", "private", "public",
   "reaction", "reactor", "realtime", "reset",
   "sec", "secs", "shutdown", "startup", "state",
   "target", "timer", "time", 

--- a/packages/lingua-franca/src/lib/documentationNavigation.ts
+++ b/packages/lingua-franca/src/lib/documentationNavigation.ts
@@ -250,6 +250,12 @@ export function getDocumentationNavForLanguage(
           permalink: "/docs/handbook/arduino",
           oneline: "Developing LF Programs on Arduino.",
         },
+        {
+          title: "Zephyr",
+          id: "4-zephyr",
+          permalink: "/docs/handbook/zephyr",
+          oneline: "Developing LF Programs for Zephyr RTOS.",
+        },
       ],
     },
     {


### PR DESCRIPTION
This PR documents how to use preambles in the C target after @petervdonovan's redesign that generates more modular C code. The instructions are compatible with the latest release (the code snippets will work), so I think we can merge this right away. We don't need to wait for a new release.