### PR TITLE
Fix broken link on front page

### DIFF
--- a/packages/lingua-franca/src/components/QuickJump.tsx
+++ b/packages/lingua-franca/src/components/QuickJump.tsx
@@ -31,7 +31,7 @@ export const QuickJump = (props: Props) => {
             <IntlLink to="/docs/handbook/overview">Overview</IntlLink>
           </li>
           <li>
-            <IntlLink to="/docs/handbook/download">Download and Build</IntlLink>
+            <IntlLink to="/docs/handbook/developer-setup">Download and Build</IntlLink>
           </li>
           <li>
             <IntlLink to="/docs/handbook/tutorial-video">Tutorial Video (EMSOFT 2021)</IntlLink>


### PR DESCRIPTION
This page https://www.lf-lang.org/docs/ has a broken link to what i suppose is this page: https://github.com/lf-lang/lf-lang.github.io/blob/e7d13daebd16aae0fff0602e4c3451b8b758e95d/packages/documentation/copy/en/developer/Downloading%20and%20Building.md?plain=1