### PR TITLE
Fix typo in Zephyr docs

### DIFF
--- a/packages/documentation/copy/en/embedded/Zephyr.md
+++ b/packages/documentation/copy/en/embedded/Zephyr.md
@@ -55,7 +55,7 @@ be activated every time you want to use west with LF**
 1. Download and install Zephyr SDK to `/opt`
 ```
 cd ~
-wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.15.2/zephyr-sdk-0.16.1_linux-x86_64.tar.xz
+wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.1/zephyr-sdk-0.16.1_linux-x86_64.tar.xz
 wget -O - https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.1/sha256.sum | shasum --check --ignore-missing
 
 tar xvf zephyr-sdk-0.16.1_linux-x86_64.tar.xz --directory /opt/


### PR DESCRIPTION
Fix typo in Zephyr docs