### PR TITLE
Added sudo to download instructions

### DIFF
--- a/packages/lingua-franca/src/templates/pages/download.tsx
+++ b/packages/lingua-franca/src/templates/pages/download.tsx
@@ -72,7 +72,7 @@ const Index: React.FC<Props> = (props) => {
               <p><code>curl -Ls https://install.lf-lang.org | sudo sh -s epoch nightly</code></p>
           </p>
           <p>You can use the <code>--prefix=&lt;path&gt;</code> argument to change the default install location.</p>
-          <p>You may not need the <code>sudo</code> part if you permission to write to the install location.</p>
+          <p>You may not need the <code>sudo</code> part if you have permission to write to the install location.</p>
       </div>
       <div style={{borderTop: "1px lightgray solid"}}>
           <h3>AUR</h3>

--- a/packages/lingua-franca/src/templates/pages/download.tsx
+++ b/packages/lingua-franca/src/templates/pages/download.tsx
@@ -66,12 +66,13 @@ const Index: React.FC<Props> = (props) => {
       <div style={{borderTop: "1px lightgray solid"}}>
           <h3>Install Script</h3>
           <p>Run the following command in your terminal to install the latest release (on Windows, use WSL):
-              <p><code>curl -Ls https://install.lf-lang.org | sh -s epoch</code></p>
+              <p><code>curl -Ls https://install.lf-lang.org | sudo sh -s epoch</code></p>
           </p>
           <p>You can also install the nightly pre-release:
-              <p><code>curl -Ls https://install.lf-lang.org | sh -s epoch nightly</code></p>
+              <p><code>curl -Ls https://install.lf-lang.org | sudo sh -s epoch nightly</code></p>
           </p>
           <p>You can use the <code>--prefix=&lt;path&gt;</code> argument to change the default install location.</p>
+          <p>You may not need the <code>sudo</code> part if you permission to write to the install location.</p>
       </div>
       <div style={{borderTop: "1px lightgray solid"}}>
           <h3>AUR</h3>

--- a/packages/lingua-franca/src/templates/pages/download.tsx
+++ b/packages/lingua-franca/src/templates/pages/download.tsx
@@ -66,13 +66,15 @@ const Index: React.FC<Props> = (props) => {
       <div style={{borderTop: "1px lightgray solid"}}>
           <h3>Install Script</h3>
           <p>Run the following command in your terminal to install the latest release (on Windows, use WSL):
-              <p><code>curl -Ls https://install.lf-lang.org | sudo sh -s epoch</code></p>
+              <p><code>curl -Ls https://install.lf-lang.org | sh -s epoch</code></p>
           </p>
           <p>You can also install the nightly pre-release:
-              <p><code>curl -Ls https://install.lf-lang.org | sudo sh -s epoch nightly</code></p>
+              <p><code>curl -Ls https://install.lf-lang.org | sh -s epoch nightly</code></p>
           </p>
           <p>You can use the <code>--prefix=&lt;path&gt;</code> argument to change the default install location.</p>
-          <p>You may not need the <code>sudo</code> part if you have permission to write to the install location.</p>
+          <p>The default prefix is <code>/usr/local/bin</code> on a Mac and <code>~/.local/bin</code> on Linux and WSL.
+            You may not have write access to this directory by default, in which case, if you still want to use the default prefix,
+            you can replace <code>sh</code> with <code>sudo sh</code> in the above commands.</p>
       </div>
       <div style={{borderTop: "1px lightgray solid"}}>
           <h3>AUR</h3>


### PR DESCRIPTION
On MacOS Sonoma, at least, the Epoch install script has to be run with `sudo`.