### PR TITLE
Re-enable contextual search

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -130,8 +130,8 @@ const config: Config = {
       appId: 'U5IWIJW31Z',
       // Public API key: it is safe to commit it
       apiKey: '4c0c2881412ae05e0663742765d5a0d3',
-      indexName: 'lf-lang', //TODO: change this otherwise 404
-      contextualSearch: false,
+      indexName: 'lf-lang', 
+      contextualSearch: true,
     }
   } satisfies Preset.ThemeConfig,
 


### PR DESCRIPTION
Appears to be an Algolia issue, we need to delete the index and re-crawl

This effectively reverts a0e3839691a03ebc69cad0c637c009b9247c2289