### PR TITLE
Fix minor typo and update name of script

### DIFF
--- a/docs/embedded/zephyr.mdx
+++ b/docs/embedded/zephyr.mdx
@@ -150,7 +150,7 @@ hi-resolution timing. These required configurations are stored in a file called
 `prj_lf.conf` which `lfc` generates into the `src-gen` folder. You can provide
 your own configurations through the following three files that `west lfc`
 expects to find at the root of each app:
-1. `prj.conf`, see [Seeting symbols in Configuration systems (Kconfig)](https://docs.zephyrproject.org/latest/build/kconfig/setting.html#setting-symbols-in-configuration-files) 
+1. `prj.conf`, see [Setting symbols in Configuration systems (Kconfig)](https://docs.zephyrproject.org/latest/build/kconfig/setting.html#setting-symbols-in-configuration-files) 
 2. `Kconfig`, see [Configuration system (Kconfig)](https://docs.zephyrproject.org/latest/build/kconfig/index.html)
 3. `app.overlay`, see [Devicetree](https://docs.zephyrproject.org/latest/build/dts/index.html#devicetree)
 
@@ -168,7 +168,7 @@ you have just built.
 
 # The `west lfc` command
 The custom `lfc` west command has already been used in previous sections. It can
-be inspected in `scripts/lf_build.py`. It invokes `lfc` on the provided LF
+be inspected in `scripts/lfc.py`. It invokes `lfc` on the provided LF
 source file. It also copies `app.overlay`,`prj.conf` and `Kconfig` into the
 src-gen directory before it, optionally, calls `west build` on the resulting
 project.

--- a/docs/embedded/zephyr.mdx
+++ b/docs/embedded/zephyr.mdx
@@ -173,7 +173,7 @@ source file. It also copies `app.overlay`,`prj.conf` and `Kconfig` into the
 src-gen directory before it, optionally, calls `west build` on the resulting
 project.
 
-Please see `west lfc --help` for more information and the `scripts/lf_build.py`.
+Please see `west lfc --help` for more information and the `scripts/lfc.py`.
 
 # LFC-centric development
 In this guide we have shown how LF Zephyr apps can be developed in a

--- a/versioned_docs/version-0.5.0/embedded/zephyr.mdx
+++ b/versioned_docs/version-0.5.0/embedded/zephyr.mdx
@@ -157,12 +157,12 @@ expects to find at the root of each app:
 
 # The `west lfc` command
 The custom `lfc` west command has already been used in previous sections. It can
-be inspected in `scripts/lf_build.py`. It invokes `lfc` on the provided LF
+be inspected in `scripts/lfc.py`. It invokes `lfc` on the provided LF
 source file. It also copies `app.overlay`,`prj.conf` and `Kconfig` into the
 src-gen directory before it, optionally, calls `west build` on the resulting
 project.
 
-Please see `west lfc --help` for more information and the `scripts/lf_build.py`.
+Please see `west lfc --help` for more information and the `scripts/lfc.py`.
 
 # LFC-centric development
 In this guide we have shown how LF Zephyr apps can be developed in a

--- a/versioned_docs/version-0.6.0/embedded/zephyr.mdx
+++ b/versioned_docs/version-0.6.0/embedded/zephyr.mdx
@@ -168,12 +168,12 @@ you have just built.
 
 # The `west lfc` command
 The custom `lfc` west command has already been used in previous sections. It can
-be inspected in `scripts/lf_build.py`. It invokes `lfc` on the provided LF
+be inspected in `scripts/lfc.py`. It invokes `lfc` on the provided LF
 source file. It also copies `app.overlay`,`prj.conf` and `Kconfig` into the
 src-gen directory before it, optionally, calls `west build` on the resulting
 project.
 
-Please see `west lfc --help` for more information and the `scripts/lf_build.py`.
+Please see `west lfc --help` for more information and the `scripts/lfc.py`.
 
 # LFC-centric development
 In this guide we have shown how LF Zephyr apps can be developed in a


### PR DESCRIPTION
The guide says the script in lf-west-template is called lf_build.py, but is is named lfc.py. 

See here: https://github.com/lf-lang/lf-west-template/tree/main/scripts