### PR TITLE
Fixed description of the build-type property, default to debug

### DIFF
--- a/docs/reference/target-declaration.mdx
+++ b/docs/reference/target-declaration.mdx
@@ -25,7 +25,7 @@ A target specification may have optional parameters, the names and values of whi
 
 - [**auth**](#auth): A boolean specifying to apply authorization between RTI and federates when federated execution.
 - [**build**](#build): A command to execute after code generation instead of the default compile command.
-- [**build-type**](#build-type): One of Release (the default), Debug, RelWithDebInfo and MinSizeRel.
+- [**build-type**](#build-type): One of Debug (the default), Release, RelWithDebInfo and MinSizeRel.
 - [**cargo-dependencies**](#cargo-dependencies): (Rust only) list of dependencies to include in the generated Cargo.toml file.
 - [**cargo-features**](#cargo-features): (Rust only) List of string names of features to include.
 - [**cmake**](#cmake): Whether to use cmake for building.
@@ -56,7 +56,7 @@ c={
 `target C {
     auth: <true or false>
     build: <string>,
-    build-type: <Release, Debug, RelWithDebInfo, or MinSizeRel>,
+    build-type: <Debug, Release, RelWithDebInfo, or MinSizeRel>,
     cmake: <true or false>,
     cmake-include: <string or list of strings>,
     compiler: <string>,
@@ -74,7 +74,7 @@ c={
 } 
 cpp={
 `target Cpp {
-    build-type: <Release, Debug, RelWithDebInfo, or MinSizeRel>,
+    build-type: <Debug, Release, RelWithDebInfo, or MinSizeRel>,
     cmake-include: <string or list of strings>,
     external-runtime-path: <string>,
     export-dependency-graph <true or false>,
@@ -221,25 +221,15 @@ This target does not currently support the `build` target option.
 <ShowIf ts py>
 This target does not currently support the `build-type` target option.
 </ShowIf>
-<ShowIf rs>
-This parameter works with `cargo` to specify how to compile the code. The following options are supported:
+<ShowIf rs c cpp>
+This parameter specifies how to compile the code. The following options are supported:
 
-- `Release`: Optimization is turned on and debug information is missing.
-- `Debug`: Debug information is included in the executable.
+- `Debug`: Optimization is disabled and debug information is included in the executable.
+- `Release`: Optimization is enabled and debug information is missing.
 - `RelWithDebInfo`: Optimization with debug information.
 - `MinSizeRel`: Optimize for smallest size.
 
-This defaults to `Release`.
-</ShowIf>
-<ShowIf c cpp>
-This parameter works with `cmake` to specify how to compile the code. The following options are supported:
-
-- `Release`: Optimization is turned on and debug information is missing.
-- `Debug`: Debug information is included in the executable.
-- `RelWithDebInfo`: Optimization with debug information.
-- `MinSizeRel`: Optimize for smallest size.
-
-This defaults to `Release`.
+This defaults to `Debug`.
 </ShowIf>
 </ShowIfs>
 

--- a/versioned_docs/version-0.6.0/reference/target-declaration.mdx
+++ b/versioned_docs/version-0.6.0/reference/target-declaration.mdx
@@ -25,7 +25,7 @@ A target specification may have optional parameters, the names and values of whi
 
 - [**auth**](#auth): A boolean specifying to apply authorization between RTI and federates when federated execution.
 - [**build**](#build): A command to execute after code generation instead of the default compile command.
-- [**build-type**](#build-type): One of Release (the default), Debug, RelWithDebInfo and MinSizeRel.
+- [**build-type**](#build-type): One of Debug (the default), Release, RelWithDebInfo and MinSizeRel.
 - [**cargo-dependencies**](#cargo-dependencies): (Rust only) list of dependencies to include in the generated Cargo.toml file.
 - [**cargo-features**](#cargo-features): (Rust only) List of string names of features to include.
 - [**cmake**](#cmake): Whether to use cmake for building.
@@ -56,7 +56,7 @@ c={
 `target C {
     auth: <true or false>
     build: <string>,
-    build-type: <Release, Debug, RelWithDebInfo, or MinSizeRel>,
+    build-type: <Debug, Release, RelWithDebInfo, or MinSizeRel>,
     cmake: <true or false>,
     cmake-include: <string or list of strings>,
     compiler: <string>,
@@ -74,7 +74,7 @@ c={
 } 
 cpp={
 `target Cpp {
-    build-type: <Release, Debug, RelWithDebInfo, or MinSizeRel>,
+    build-type: <Debug, Release, RelWithDebInfo, or MinSizeRel>,
     cmake-include: <string or list of strings>,
     external-runtime-path: <string>,
     export-dependency-graph <true or false>,
@@ -221,25 +221,15 @@ This target does not currently support the `build` target option.
 <ShowIf ts py>
 This target does not currently support the `build-type` target option.
 </ShowIf>
-<ShowIf rs>
-This parameter works with `cargo` to specify how to compile the code. The following options are supported:
+<ShowIf rs c cpp>
+This parameter specifies how to compile the code. The following options are supported:
 
-- `Release`: Optimization is turned on and debug information is missing.
-- `Debug`: Debug information is included in the executable.
+- `Debug`: Optimization is disabled and debug information is included in the executable.
+- `Release`: Optimization is enabled and debug information is missing.
 - `RelWithDebInfo`: Optimization with debug information.
 - `MinSizeRel`: Optimize for smallest size.
 
-This defaults to `Release`.
-</ShowIf>
-<ShowIf c cpp>
-This parameter works with `cmake` to specify how to compile the code. The following options are supported:
-
-- `Release`: Optimization is turned on and debug information is missing.
-- `Debug`: Debug information is included in the executable.
-- `RelWithDebInfo`: Optimization with debug information.
-- `MinSizeRel`: Optimize for smallest size.
-
-This defaults to `Release`.
+This defaults to `Debug`.
 </ShowIf>
 </ShowIfs>
 


### PR DESCRIPTION
https://github.com/lf-lang/lingua-franca/pull/2008 changed the default behavior of the `build-type` property to `Debug`. This updates the documentation accordingly. 