### PR TITLE
Update Arduino instructions to LF_SINGLE_THREADED instead of LF_THREA…

### DIFF
--- a/docs/embedded/arduino.mdx
+++ b/docs/embedded/arduino.mdx
@@ -107,10 +107,10 @@ The common board families include `avr`, `megaAVR`, `sam`, `samd`, and `mbed`.
 If you specify your FQBN under `board` in the `platform` target property, `lfc` will automatically invoke `arduino-cli` on the generated sketch. To invoke `arduino-cli` manually
 
 - for unthreaded programs (most arduino flavors), run:
-  `arduino-cli compile -b [FQBN] --build-property compiler.c.extra_flags="-DLF_UNTHREADED -DPLATFORM_ARDUINO -DINITIAL_EVENT_QUEUE_SIZE=10 -DINITIAL_REACT_QUEUE_SIZE=10" --build-property compiler.cpp.extra_flags="-DLF_UNTHREADED -DPLATFORM_ARDUINO -DINITIAL_EVENT_QUEUE_SIZE=10 -DINITIAL_REACT_QUEUE_SIZE=10"`
+  `arduino-cli compile -b [FQBN] --build-property compiler.c.extra_flags="-DLF_SINGLE_THREADED=1 -DPLATFORM_ARDUINO -DINITIAL_EVENT_QUEUE_SIZE=10 -DINITIAL_REACT_QUEUE_SIZE=10" --build-property compiler.cpp.extra_flags="-DLF_SINGLE_THREADED=1 -DPLATFORM_ARDUINO -DINITIAL_EVENT_QUEUE_SIZE=10 -DINITIAL_REACT_QUEUE_SIZE=10"`
 
 - for threaded programs (`arduino:mbed` boards), run:
-  `arduino-cli compile -b [FQBN] --build-property compiler.c.extra_flags="-DLF_THREADED -DPLATFORM_ARDUINO -DINITIAL_EVENT_QUEUE_SIZE=10 -DINITIAL_REACT_QUEUE_SIZE=10" --build-property compiler.cpp.extra_flags="-DLF_THREADED -DPLATFORM_ARDUINO -DINITIAL_EVENT_QUEUE_SIZE=10 -DINITIAL_REACT_QUEUE_SIZE=10"`
+  `arduino-cli compile -b [FQBN] --build-property compiler.c.extra_flags="-DPLATFORM_ARDUINO -DINITIAL_EVENT_QUEUE_SIZE=10 -DINITIAL_REACT_QUEUE_SIZE=10" --build-property compiler.cpp.extra_flags="-DPLATFORM_ARDUINO -DINITIAL_EVENT_QUEUE_SIZE=10 -DINITIAL_REACT_QUEUE_SIZE=10"`
 
 # Flashing
 


### PR DESCRIPTION
…DED/LF_UNTHREADED

At some point, the `#define` macros `LF_THREADED` and `LF_UNTHREADED` were replaced with `LF_SINGLE_THREADED`. This PR updates the Arduino docs to set that `-D` option when unthreaded execution is desired.