### PR TITLE
Fixed instructions for setting parameters from a table

### DIFF
--- a/docs/assets/code/c/src/BankIndex.lf
+++ b/docs/assets/code/c/src/BankIndex.lf
@@ -1,12 +1,11 @@
 target C;
-preamble {=
-  int table[] = {4, 3, 2, 1};
-=}
 reactor A(bank_index:int = 0, value:int = 0) {
   reaction (startup) {=
     printf("bank_index: %d, value: %d\n", self->bank_index, self->value);
   =}
 }
-main reactor {
-  a = new[4] A(value = {= table[bank_index] =});
+main reactor(
+  table: int[] = {4, 3, 2, 1}
+) {
+  a = new[4] A(value = {= self->table[bank_index] =});
 }

--- a/docs/assets/code/py/src/BankIndex.lf
+++ b/docs/assets/code/py/src/BankIndex.lf
@@ -1,12 +1,11 @@
 target Python;
-preamble {=
-  table = [4, 3, 2, 1]
-=}
 reactor A(bank_index = 0, value = 0) {
   reaction (startup) {=
     print("bank_index: {:d}, value: {:d}".format(self.bank_index, self.value))
   =}
 }
-main reactor {
-  a = new[4] A(value = {= table[bank_index] =})
+main reactor(
+  table = [4, 3, 2, 1]
+) {
+  a = new[4] A(value = {= self.table[bank_index] =})
 }

--- a/docs/writing-reactors/multiports-and-banks.mdx
+++ b/docs/writing-reactors/multiports-and-banks.mdx
@@ -204,7 +204,7 @@ import Py_BankIndex from '../assets/code/py/src/BankIndex.lf';
 
 <NoSelectorTargetCodeBlock c={C_BankIndex}  py={Py_BankIndex} lf />
 
-The global `table` defined in the `preamble` is used to initialize the `value` parameter of each bank member. The result of running this is something like:
+The parameter `table` defined in the `main reactor` is used to initialize the `value` parameter of each bank member. The result of running this is something like:
 
 ```
 bank_index: 0, value: 4

--- a/versioned_docs/version-0.8.0/assets/code/c/src/BankIndex.lf
+++ b/versioned_docs/version-0.8.0/assets/code/c/src/BankIndex.lf
@@ -1,12 +1,11 @@
 target C;
-preamble {=
-  int table[] = {4, 3, 2, 1};
-=}
 reactor A(bank_index:int = 0, value:int = 0) {
   reaction (startup) {=
     printf("bank_index: %d, value: %d\n", self->bank_index, self->value);
   =}
 }
-main reactor {
-  a = new[4] A(value = {= table[bank_index] =});
+main reactor(
+  table: int[] = {4, 3, 2, 1}
+) {
+  a = new[4] A(value = {= self->table[bank_index] =});
 }

--- a/versioned_docs/version-0.8.0/writing-reactors/multiports-and-banks.mdx
+++ b/versioned_docs/version-0.8.0/writing-reactors/multiports-and-banks.mdx
@@ -204,7 +204,12 @@ import Py_BankIndex from '../assets/code/py/src/BankIndex.lf';
 
 <NoSelectorTargetCodeBlock c={C_BankIndex}  py={Py_BankIndex} lf />
 
+<ShowOnly py>
 The global `table` defined in the `preamble` is used to initialize the `value` parameter of each bank member. The result of running this is something like:
+</ShowOnly>
+<ShowOnly c>
+The parameter `table` defined in the `main reactor` is used to initialize the `value` parameter of each bank member. The result of running this is something like:
+</ShowOnly>
 
 ```
 bank_index: 0, value: 4


### PR DESCRIPTION
This addresses [this comment](https://github.com/lf-lang/lingua-franca/issues/1705#issuecomment-2211359950) about duplicate symbols error occurring when following website instructions to initialize parameters from a table.

The Python version of this fix relies on [PR 2353 in lingua-franca](https://github.com/lf-lang/lingua-franca/pull/2353).

I have updated the version 0.8 docs for the C target only because the Python fix above is not in version 0.8 and the Python code works, albeit inefficiently.  The C code, however, does not compile in version 0.8, so it needed to be fixed.