### PR TITLE
Fixed description of sparse inputs

### DIFF
--- a/docs/assets/code/c/src/Sparse.lf
+++ b/docs/assets/code/c/src/Sparse.lf
@@ -1,7 +1,6 @@
 target C;
 reactor Sparse {
-  @sparse
-  input[100] in:int;
+  input[100] in: int
   reaction(in) {=
     // Create an iterator over the input channels.
     struct lf_multiport_iterator_t i = lf_multiport_iterator(in);

--- a/docs/writing-reactors/multiports-and-banks.mdx
+++ b/docs/writing-reactors/multiports-and-banks.mdx
@@ -84,18 +84,13 @@ In the Python target, multiports can be iterated on in a for loop (e.g., `for p 
 
 Sometimes, a program needs a wide multiport input, but when reactions are triggered by this input, few of the channels are present.
 In this case, it can be inefficient to iterate over all the channels to determine which are present.
-If you know that a multiport input will be **sparse** in this way, then you can provide a hint to the compiler and use a more efficient iterator to access the port. For example:
+If you know that a multiport input will be **sparse** in this way, then you can use a more efficient iterator to access the port. For example:
 
 import C_Sparse from '../assets/code/c/src/Sparse.lf';
 
 <NoSelectorTargetCodeBlock c={C_Sparse} lf />
 
-Notice the `@sparse` annotation on the input declaration.
-This provides a hint to the compiler to optimize for sparse inputs.
-Then, instead of iterating over all input channels, this code uses the built-in function `lf_multiport_iterator()` to construct an iterator. The function `lf_multiport_next()` returns the first (and later, the next) channel index that is present. It returns -1 when no more channels have present inputs.
-
-The multiport iterator can be used for any input multiport, even if it is not marked sparse.
-But if it is not marked sparse, then the `lf_multiport_next()` function will not optimize for sparse inputs and will simply iterate over the channels until it finds one that is present.
+Instead of iterating over all input channels, this code uses the built-in function `lf_multiport_iterator()` to construct an iterator. The function `lf_multiport_next()` returns the first (and later, the next) channel index that is present. It returns -1 when no more channels have present inputs.
 
 </ShowOnly>
 

--- a/versioned_docs/version-0.8.0/assets/code/c/src/Sparse.lf
+++ b/versioned_docs/version-0.8.0/assets/code/c/src/Sparse.lf
@@ -1,6 +1,5 @@
 target C;
 reactor Sparse {
-  @sparse
   input[100] in:int;
   reaction(in) {=
     // Create an iterator over the input channels.

--- a/versioned_docs/version-0.8.0/writing-reactors/multiports-and-banks.mdx
+++ b/versioned_docs/version-0.8.0/writing-reactors/multiports-and-banks.mdx
@@ -90,12 +90,7 @@ import C_Sparse from '../assets/code/c/src/Sparse.lf';
 
 <NoSelectorTargetCodeBlock c={C_Sparse} lf />
 
-Notice the `@sparse` annotation on the input declaration.
-This provides a hint to the compiler to optimize for sparse inputs.
-Then, instead of iterating over all input channels, this code uses the built-in function `lf_multiport_iterator()` to construct an iterator. The function `lf_multiport_next()` returns the first (and later, the next) channel index that is present. It returns -1 when no more channels have present inputs.
-
-The multiport iterator can be used for any input multiport, even if it is not marked sparse.
-But if it is not marked sparse, then the `lf_multiport_next()` function will not optimize for sparse inputs and will simply iterate over the channels until it finds one that is present.
+Instead of iterating over all input channels, this code uses the built-in function `lf_multiport_iterator()` to construct an iterator. The function `lf_multiport_next()` returns the first (and later, the next) channel index that is present. It returns -1 when no more channels have present inputs.
 
 </ShowOnly>
 


### PR DESCRIPTION
The `@sparse` annotation is not recognized any more. I've fixed the sample code and the description for both the nightly build and the 0.8 release.