### PR TITLE
Fix typos

### DIFF
--- a/docs/writing-reactors/actions.mdx
+++ b/docs/writing-reactors/actions.mdx
@@ -21,7 +21,7 @@ An action declaration has one of the following forms:
 ```
 
 The `min_delay`, `min_spacing`, and `policy` are all optional.
-If only one argument is given in parentheses, then it is interpreted as an `min_delay`,
+If only one argument is given in parentheses, then it is interpreted as a `min_delay`,
 if two are given, then they are interpreted as `min_delay` and `min_spacing`.
 The `min_delay` and `min_spacing` are time values.
 The `policy` argument is a string that can be one of the following:

--- a/docs/writing-reactors/reactions.mdx
+++ b/docs/writing-reactors/reactions.mdx
@@ -26,7 +26,7 @@ Each reaction declares its triggers, uses, and effects:
 
 Reactions may optionally be named. The name is cosmetic and may serve as additional documentation. Note that reactions cannot be called like functions, even if they are named.
 
-The reaction's behavior is defined by its body, which should be given in the target programming language. Note that the reaction body may only read from actions and ports that it has declared as triggers or uses, and it may only write to actions and ports that is has declared as an effect. The target code generators implement a scoping mechanism, such that only variables that are declared in the reaction signature are accessible in the reaction body.
+The reaction's behavior is defined by its body, which should be given in the target programming language. Note that the reaction body may only read from actions and ports that it has declared as triggers or uses, and it may only write to actions and ports that it has declared as an effect. The target code generators implement a scoping mechanism, such that only variables that are declared in the reaction signature are accessible in the reaction body.
 
 In some targets, the reaction body may be omitted and the body can be defined natively in the target language in an external file. See the section on [Bodyless Reactions](#bodyless-reactions) for details.
 


### PR DESCRIPTION
 `writing-reactors/reactions`: Replace "is" with "it"
`writing-reactors/actions`: Replace "an" with "a"