### PR TITLE
Update docs to Zephyr v3.7.0

### DIFF
--- a/docs/embedded/zephyr.mdx
+++ b/docs/embedded/zephyr.mdx
@@ -21,10 +21,10 @@ Zephyr RTOS sources.
 - nrf52 Development Kit (optional)
 
 # Getting started
-The first step is to set up a proper Zephyr development environment. Follow the
+The first step is to set up a proper Zephyr v3.7.0 development environment. Follow the
 steps in the **Install dependencies** and **Install Zephyr SDK** sections of the
 official [Zephyr Getting Started
-Guide](https://docs.zephyrproject.org/latest/develop/getting_started/index.html).
+Guide](https://docs.zephyrproject.org/3.7.0/develop/getting_started/index.html).
 Do not perform the steps under **Get Zephyr and install Python
 dependencies**. These steps will be performed inside the LF Zephyr workspace we
 are going to create next.
@@ -68,8 +68,8 @@ pip install -r deps/zephyr/scripts/requirements.txt
 ## Workspace organization
 Now you should have the following installed:
 -`west`; Verify with `west boards`
-- Zephyr SDK located at `/opt/zephyr-sdk-VERSION`
-- Zephyr RTOS pulled down to `deps/zephyr`
+- Zephyr SDK v0.16.8 located at `/opt/zephyr-sdk-0.16.8`
+- Zephyr RTOS v3.7.0 pulled down to `deps/zephyr`
 - A few example applications under `apps/`
 
 This workspace is meant to house all of your different LF Zephyr apps, as long


### PR DESCRIPTION
Update docs to point to Zephyr v3.7.0 and SDK v0.16.8