### PR TITLE
New blog about how to create and publish packages

### DIFF
--- a/blog/2024-11-11-package.md
+++ b/blog/2024-11-11-package.md
@@ -1,0 +1,119 @@
+---
+slug: packages
+title: Guide to Creating and Publishing a Package
+authors: [vinzbarbuto]
+tags: [packages, packaging, lingua franca, docs]
+---
+
+The Lingua Franca (LF) [Package Explorer](/docs/tools/code-extension#package-explorer) is a powerful feature within the Lingua Franca VS Code extension, built to streamline package management for developers. Supporting both local and remote sources, the Package Explorer enables effortless listing and management of packages—whether defined locally by developers or installed through the Lingo Package Manager. This integration aligns with the Lingua Franca community’s vision for a collaborative and reusable ecosystem. Developers can create and publish their own packages, enabling others to easily incorporate these resources into their projects. This collaborative model not only enhances programmability and accelerates product development but also simplifies the design of complex Lingua Franca applications.
+
+{/* truncate */}
+
+In this guide, we’ll walk you through the essential steps to create and publish a package to the community repository, covering:
+
+1. [**Creating a New Package**](#creating-a-package)  
+   Get started by setting up your package with the required files and directory structure to meet Lingua Franca standards.
+
+2. [**Configuring the `Lingo.toml` File**](#configuring-the-lingotoml-file)  
+   Set up the `Lingo.toml` configuration to ensure compatibility with the Lingo Package Manager, making your package easy to download and install.
+
+3. [**Publishing to the Community Repository**](#publishing-to-the-community-repository)  
+   Learn how to publish your package to the [Lingua Franca Community Package Repository](https://github.com/lf-pkgs) to share it with the broader community.
+
+By the end of this guide, you'll have a fully configured, shareable package ready to distribute within the Lingua Franca ecosystem.
+
+## Creating a New Package
+You can create a new [LF package](/docs/glossary/glossaryx#package) either manually by creating an [LF file](/docs/glossary/glossaryx#lf-file) or by using the [Lingo Package Manager](https://github.com/lf-lang/lingo).
+
+#### Option 1: Create a Project Using the Lingo Package Manager
+1. After [installing the Lingo Package Manager](https://www.lf-lang.org/docs/installation#lingo), create an empty directory to serve as the root of your new package.
+2. Open the folder in VS Code.
+3. Open the terminal in this folder and run the <kbd>lingo init</kbd> command. 
+
+This will set up a new LF package with the following structure:
+
+```
+├── .
+│   ├── src/
+│   │  └── Main.lf
+└── └── Lingo.toml # Configuration file for current package
+```
+
+#### Option 2: Create a New [LF File](/docs/glossary/glossaryx#lf-file)
+1. Go to <kbd>File > New File...</kbd> and select `New Lingua Franca File`.
+2. Save the file in a directory called `src` to ensure that generated code is placed in a parallel `src-gen` directory. For example, if your file is called `Foo.lf`, the directory structure after building will look like this:
+
+```
+├── .
+│   ├── bin/
+│   │  └── Foo
+│   ├── src/
+│   │  └── Foo.lf
+│   ├── src-gen/
+│   │  └── Foo/
+...
+```
+
+If you manually create the `Lingo.toml` file, place it adjacent to the `src` folder in the root directory of the package. This file serves as a configuration for the package, allowing you to specify the package name, version, and other metadata, including any dependencies you want to install.
+
+### Add `src/lib/` for Local Libraries
+
+To include local libraries, create a `lib` directory within the `src/` folder and place your LF files there. These files contain reusable reactors that can be used within the same package or, if published, in other packages via the Lingo Package Manager. This setup makes it easy to manage and reuse libraries across Lingua Franca projects. The `lib` directory should be placed alongside the `src` directory, organized as follows:
+
+```
+├── .
+│   ├── src/
+│   │   ├── lib/
+│   │   │   ├── private/
+│   │   │   │   └── AbstractLibraryFile.lf
+│   │   │   ├── LibraryFile_1.lf
+│   │   │   └── LibraryFile_2.lf
+│   │   └── Foo.lf
+...
+```
+
+In LF, there is no visibility control, meaning you cannot mark a reactor or file as `private` as in other programming languages. The `private` directory serves this purpose by containing files meant solely for internal package use. Files in this directory are hidden in the Package Explorer within the VS Code extension, making them inaccessible to other packages. The `private` directory is useful for implementing design patterns like the Abstract Factory Pattern, which provides an interface for creating families of related objects without specifying concrete classes. For example, a developer might define an `AbstractLibraryFile.lf` containing abstract reactors and implement them in various ways within different files under the `lib` directory.
+
+### Must-Follow Guidelines
+
+When creating a new package, ensure that you follow these guidelines:
+
+- **README.md**: Include a `README.md` file in the root directory. This should provide an overview of the package, its purpose, a description of the LF files in the `lib/` folder, and relevant user information. The `README.md` is essential for publishing your package to the community repository and must be kept up to date.
+
+- **File Naming**: Use descriptive names for files in the `lib/` directory that reflect their purpose. For example, name a file containing a reactor for different sensors as `Sensor.lf`.
+
+- **Example LF Files**: Include example LF files in the `src/` directory to demonstrate how to use the reactors in the `lib/` directory. These examples should be well-documented with comments explaining the purpose and usage of each reactor.
+
+## Configuring the `Lingo.toml` File
+
+The `Lingo.toml` file is a configuration file that provides essential information about your package, such as its name, version, and dependencies. It ensures that your package is recognized and installed correctly by the Lingo Package Manager. The `Lingo.toml` file should include the following sections:
+
+- **`[package]`**: Specify the package name, description, and version.
+
+- **`[lib]`**: Define the package name, the target language used to implement the code, the main reactor (which could be one of the examples from the `src/` directory), and the platform used to build the package.
+
+Here's an example of a `Lingo.toml` file:
+
+```toml
+[package]
+name = "PackageName"
+version = "0.3.1"
+
+[properties]
+
+[lib]
+name = "PackageName"
+main = "./src/Main.lf"
+target = "Python"
+platform = "Native"
+
+[lib.properties]
+
+[dependencies]
+```
+
+The `Lingo.toml` can also include additional sections for dependencies and other purpose-specific configurations, however, these are optional and can be added as needed.
+
+## Publishing to the Community Repository
+
+TBD

--- a/blog/authors.yml
+++ b/blog/authors.yml
@@ -20,3 +20,9 @@ eal:
   title: Professor at UC Berkeley
   url: http://people.eecs.berkeley.edu/~eal/
   image_url: https://avatars.githubusercontent.com/u/8513334?v=4
+
+vinzbarbuto:
+  name: Vincenzo Barbuto  
+  title: PhD Student at University of Calabria
+  url: https://vincenzo-barbuto.netlify.app/
+  image_url: https://avatars.githubusercontent.com/u/63100303?v=4


### PR DESCRIPTION
This PR proposes adding a blog post to the website that explains how to create and publish a package to fully leverage the potential of the Lingua Franca Package Explorer in VS Code extension