### PR TITLE
Added reactor name functions

### DIFF
--- a/docs/reference/target-language-details.mdx
+++ b/docs/reference/target-language-details.mdx
@@ -2854,6 +2854,11 @@ Reactions in C can use a number of pre-defined functions, macros, and constants 
 
   - Schedule future events, such as `lf_schedule` and `lf_schedule_value` ([api.h](https://www.lf-lang.org/reactor-c/dc/d65/api_8h.html))
 
+- **Reactor Names**
+
+  - `lf_reactor_name(self)`: Returns the name of the reactor that contains the current reaction. The name is that assigned upon instantiation. If the reactor is in a bank, then the name has a suffix of the form `[bank_index]`.
+  - `lf_reactor_full_name(self)`: Returns the full name of the reactor that contains the current reaction. This is the name of the reactor and all its parent reactors, separated by periods.
+
 - **File Access**
 
   - LF_SOURCE_DIRECTORY: A C string giving the full path to the directory containing the `.lf` file of the program.


### PR DESCRIPTION
This PR adds documentation for two functions (and macros), `lf_reactor_name` and `lf_reactor_full_name`, each of which takes a self struct as an argument.  The name is the instance name given by the `new` statement. If the reactor is in a bank, then the name will have a suffix of the form `[bank_index]`.  The full name is the name of the reactor and all its parents separated by periods. There is a [companion PR in lingua-franca](https://github.com/lf-lang/lingua-franca/pull/2450).