### PR TITLE
Specify that Zephyr development needs Linux

### DIFF
--- a/docs/embedded/zephyr.mdx
+++ b/docs/embedded/zephyr.mdx
@@ -17,7 +17,7 @@ different LF Zephyr projects can be hosted together with a single copy of the
 Zephyr RTOS sources.
 
 ## Prerequisites
-- Linux or macOS development system. (The guide is written for Linux)
+- Linux development system (The guide was written and tested for Ubuntu 24.04)
 - nrf52 Development Kit (optional)
 
 # Getting started


### PR DESCRIPTION
Although it would not be that hard to get macOS support, since we are working on reactor-uc, which do support macOS I don't think it is worth it.

Addresses: https://github.com/lf-lang/lingua-franca/issues/2486